### PR TITLE
Optimize number parsing

### DIFF
--- a/ijson/common.py
+++ b/ijson/common.py
@@ -152,10 +152,11 @@ def items(prefixed_events, prefix):
 
 def number(str_value):
     '''
-    Converts string with a numeric value into an int or a Decimal.
+    Converts string with a numeric value into an int or a float.
     Used in different backends for consistent number representation.
     '''
-    number = decimal.Decimal(str_value)
-    if not ('.' in str_value or 'e' in str_value or 'E' in str_value):
-        number = int(number)
-    return number
+    try:
+        number = int(str_value)
+    except ValueError:
+        number = float(str_value)
+    return number    

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,11 @@
 from importlib import import_module
 
 from setuptools import setup, find_packages
+import subprocess
 
 setup(
     name = 'ijson',
-    version = import_module('ijson').__version__,
+    version=subprocess.check_output("git describe --tags --match '[0-9]*.[0-9]*'", shell=True).strip(),
     author = 'Ivan Sagalaev',
     author_email = 'maniac@softwaremaniacs.org',
     url = 'https://github.com/isagalaev/ijson',


### PR DESCRIPTION
@jeffkistler 
Changed from using decimal to float, after trying int.
Creating many decimals is slow, and most other json decoders use float by default.